### PR TITLE
Add Wayland compatiblity

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Type in Morse code by repeatedly slamming your laptop shut
 * [evemu](https://freedesktop.org/wiki/Evemu/)
 * [acpid](https://wiki.archlinux.org/index.php/Acpid)
 
+### Choosing your keyboard
+Use `evemu-describe` to find the correct path for your keyboard device and replace `KEYBOARD_DEV` in `morse_code_open.sh` with it. 
+
 ### Installation
 Clone this repository and copy files into `/etc/acpi`
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Type in Morse code by repeatedly slamming your laptop shut
 
 ## Setup
 ### Dependencies
-* [xdotool](http://manpages.ubuntu.com/manpages/trusty/man1/xdotool.1.html)
+* [evemu](https://freedesktop.org/wiki/Evemu/)
 * [acpid](https://wiki.archlinux.org/index.php/Acpid)
 
 ### Installation

--- a/morse_code_open.sh
+++ b/morse_code_open.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+readonly KEYBOARD_DEV=/dev/input/event3
+
 opened_at=$(date +%s%3N)
 pkill -f morse_code_close.sh
 
@@ -48,25 +50,25 @@ declare -A morse_letters=(
     [--...]=7
     [---..]=8
     [----.]=9
-    [.-.-.-]=.
-    [--..--]=,
+    [.-.-.-]=DOT
+    [--..--]=COMMA
     [---...]=:
     [..--..]=?
-    [.----.]="'"
-    [-....-]=-
-    [-..-.]=/
+    [.----.]=APOSTROPHE
+    [-....-]=MINUS
+    [-..-.]=SLASH
     [-.--.]='('
     [-.--.-]=')'
     [.-..-.]='"'
-    [-...-]==
+    [-...-]=EQUAL
     [.-.-.]=+
     [.--.-.]=@
 )
 
 # Grab environment variables to interact with X
 # From https://gist.github.com/AladW/de1c5676d93d05a5a0e1/
-pid=$(pgrep -t tty$(fgconsole) xinit)
-pid=$(pgrep -P $pid -n)
+pid=$(pgrep -t tty"$(fgconsole)" xinit)
+pid=$(pgrep -P "$pid" -n)
 import_environment() {
     (( pid )) && for var; do
         IFS='=' read key val < <(egrep -z "$var" /proc/$pid/environ)
@@ -98,7 +100,33 @@ sequence=$(cat /tmp/morse_code_letter)
 if [[ ! -v "morse_letters[$sequence]" ]] ; then
     exit 0
 fi
-xdotool type "${morse_letters[$sequence]}"
+
+if [[ "${morse_letters[$sequence]}" == [A-Z] ]]; then
+    evemu-event /dev/input/event3 --type EV_KEY --code KEY_LEFTSHIFT --value 1 --sync
+    evemu-event $KEYBOARD_DEV --type EV_KEY --code "KEY_${morse_letters[$sequence]}" --value 1 --sync
+    evemu-event /dev/input/event3 --type EV_KEY --code KEY_LEFTSHIFT --value 0 --sync
+elif [[ "${morse_letters[$sequence]}" =~ [A-Z0-9] ]]; then
+    evemu-event $KEYBOARD_DEV --type EV_KEY --code "KEY_${morse_letters[$sequence]}" --value 1 --sync
+else
+    evemu-event /dev/input/event3 --type EV_KEY --code KEY_LEFTSHIFT --value 1 --sync
+    if [[ "${morse_letters[$sequence]}" == ":" ]]; then
+        evemu-event $KEYBOARD_DEV --type EV_KEY --code "KEY_SEMICOLON" --value 1 --sync
+    elif [[ "${morse_letters[$sequence]}" == "?" ]]; then
+        evemu-event $KEYBOARD_DEV --type EV_KEY --code "KEY_SLASH" --value 1 --sync
+    elif [[ "${morse_letters[$sequence]}" == '"' ]]; then
+        evemu-event $KEYBOARD_DEV --type EV_KEY --code "KEY_APOSTROPHE" --value 1 --sync
+    elif [[ "${morse_letters[$sequence]}" == '(' ]]; then
+        evemu-event $KEYBOARD_DEV --type EV_KEY --code "KEY_9" --value 1 --sync
+    elif [[ "${morse_letters[$sequence]}" == ')' ]]; then
+        evemu-event $KEYBOARD_DEV --type EV_KEY --code "KEY_0" --value 1 --sync
+    elif [[ "${morse_letters[$sequence]}" == '@' ]]; then
+        evemu-event $KEYBOARD_DEV --type EV_KEY --code "KEY_2" --value 1 --sync
+    elif [[ "${morse_letters[$sequence]}" == '+' ]]; then
+        evemu-event $KEYBOARD_DEV --type EV_KEY --code "KEY_EQUAL" --value 1 --sync
+    fi
+    evemu-event /dev/input/event3 --type EV_KEY --code KEY_LEFTSHIFT --value 0 --sync
+fi
+
 rm /tmp/morse_code_letter
 
 sleep "$space_pause"


### PR DESCRIPTION
By using [evemu](https://freedesktop.org/wiki/Evemu/) we can pass keyboard commands at the kernel level instead of the X sever level, allowing this to work in a tty or Wayland session.